### PR TITLE
Fixed jQuery 1.9 compatibility and removed support for FF pre 1.9

### DIFF
--- a/jquery.bookmark.css
+++ b/jquery.bookmark.css
@@ -64,6 +64,8 @@ html:first-child .bookmark_list {  /* Opera */
 }
 .bookmark_list img {
 	border: none;
+	vertical-align: text-top;
+	*vertical-align: middle; /* IE7 and below */
 }
 #bookmark_all {
 	display: none;

--- a/jquery.bookmark.js
+++ b/jquery.bookmark.js
@@ -1,4 +1,4 @@
-﻿/* http://keith-wood.name/bookmark.html
+﻿/*! http://keith-wood.name/bookmark.html
    Sharing bookmarks for jQuery v1.4.0.
    Written by Keith Wood (kbwood{at}iinet.com.au) March 2008.
    Dual licensed under the GPL (http://dev.jquery.com/browser/trunk/jquery/GPL-LICENSE.txt) and 
@@ -264,7 +264,7 @@ $.extend(Bookmark.prototype, {
 					css('top', offset.top + target.outerHeight()).toggle();
 				return false;
 			});
-			$(document).click(function(event) { // Close on external click
+			$(document).click(function() { // Close on external click
 				target.find('.bookmark_popup').hide();
 			});
 		}
@@ -322,19 +322,10 @@ $.extend(Bookmark.prototype, {
 					'style="' + (settings.iconsStyle ? 'background-position: ' :
 					'background: transparent url(' + settings.icons + ') no-repeat ') + '-' +
 					((icon % settings.iconCols) * settings.iconSize) + 'px -' +
-					(Math.floor(icon / settings.iconCols) * settings.iconSize) + 'px;' +
-					($.browser.mozilla && $.browser.version < '1.9' ?
-					' padding-left: ' + settings.iconSize + 'px; padding-bottom: ' +
-					(Math.max(0, settings.iconSize - 16)) + 'px;' : '') + '"></span>';
+					(Math.floor(icon / settings.iconCols) * settings.iconSize) + 'px;"></span>';
 			}
 			else {
-				html += '<img src="' + icon + '" alt="' + title + '" title="' +
-					title + '"' + (($.browser.mozilla && $.browser.version < '1.9') ||
-					($.browser.msie && $.browser.version < '7.0') ?
-					' style="vertical-align: bottom;"' :
-					($.browser.msie ? ' style="vertical-align: middle;"' :
-					($.browser.opera || $.browser.safari ?
-					' style="vertical-align: baseline;"' : ''))) + '/>';
+				html += '<img src="' + icon + '" alt="' + title + '" title="' +	title + '"/>';
 			}
 			html +=	(settings.compact ? '' : '&#xa0;');
 		}
@@ -372,8 +363,8 @@ $.extend(Bookmark.prototype, {
 	   @param  url    (string) the URL to bookmark
 	   @param  title  (string) the title to bookmark */
 	_addFavourite: function(url, title) {
-		if ($.browser.msie) {
-			window.external.addFavorite(url, title);
+		if (typeof window.external.AddFavorite !== 'undefined') {
+			window.external.AddFavorite(url, title);
 		}
 		else {
 			alert(this._defaults.manualBookmark);


### PR DESCRIPTION
1. Removes $.browser references for jQuery 1.9 compatibility.
2. Prevents license block comment from being stripped by build process.
3. Uses CSS to fix icon positioning.
